### PR TITLE
The option value has to actually be "bzip2" or "pbzip2", so these are most likely typos.

### DIFF
--- a/bin/tartarus
+++ b/bin/tartarus
@@ -367,7 +367,7 @@ TAR_OPTIONS=""
 #
 # Tartarus can utilize various compression methods to the shrink the processed data
 # before storing it. Leaving the variable blank (which is the default) will disable
-# compression, other known values are "gzip", "bzip" and "pbzip".
+# compression, other known values are "gzip", "bzip2" and "pbzip2".
 COMPRESSION_METHOD=""
 #
 #=item STORAGE_METHOD


### PR DESCRIPTION
See subject. :-)
