### PR TITLE
issue #6: Double GetOpts dispatsch clause removed.

### DIFF
--- a/bin/charon.ftp
+++ b/bin/charon.ftp
@@ -151,13 +151,13 @@ GetOptions(
     "password|p=s"      => \$pass,
     "readpassword|r"    => \$read_password,
     "maxage|m=i"        => \$days_to_expire,
-    "profile|p=s"       => \$uprofile,
+    "profile"	        => \$uprofile,
     "all|a"             => \$all,
     "directory|dir|d=s" => \$dir,
     "test|dry-run|n"    => \$dry_run,
     "truncate|t"        => \$truncate,
     "verbose|v"         => \$verbose,
-    "help|h"            => \$help
+    "help"	            => \$help
 ) || usage();
 
 # which module do we use for the connection?


### PR DESCRIPTION
#### The following warnings pop-up during the _charon.ftp_ script execution:
- `Duplicate specification "profile|p=s" for option "p"`
- `Duplicate specification "help|h" for option "h"` 

The  above _GetOpts_ dispatch clauses were corrected: `p=s` and `h` removed preserving the functionality for `host` and `password` directives.

Cheers !
