### PR TITLE
Make curl create missing directories on FTP

### DIFF
--- a/bin/tartarus
+++ b/bin/tartarus
@@ -708,7 +708,7 @@ case "$STORAGE_METHOD" in
             local FILE=$(constructFilename)
             local URL="$PROTO://$STORAGE_FTP_SERVER/$STORAGE_FTP_DIR/$FILE"
             debug "Uploading backup to $URL..."
-            curl $OPTS $CURL_OPTIONS --upload-file - "$URL"
+            curl $OPTS $CURL_OPTIONS  --ftp-create-dirs --upload-file - "$URL"
         }
     ;;
     FILE)


### PR DESCRIPTION
If you use STORAGE_FTP_DIR option and the directory doesn't exist on the FTP server then the backup fails. Adding curl flag  --ftp-create-dirs makes curl create missing directories and the backup doesn't now fail.
